### PR TITLE
Precompile hamlc templates when initialize_on_precompile = false

### DIFF
--- a/lib/haml_coffee_assets/engine.rb
+++ b/lib/haml_coffee_assets/engine.rb
@@ -25,7 +25,7 @@ module HamlCoffeeAssets
 
     # Initialize Haml Coffee Assets after Sprockets
     #
-    initializer 'sprockets.hamlcoffeeassets', :after => 'sprockets.environment' do |app|
+    initializer 'sprockets.hamlcoffeeassets', :group => :all, :after => 'sprockets.environment' do |app|
       next unless app.assets
 
       # Register tilt template


### PR DESCRIPTION
Based on a Rails 3.1.1 change, and some [other commits](https://github.com/chriseppstein/compass/pull/603) I saw regarding this issue I just specified the option to the Railtie initialization to initialize even if that `initialize_on_precompile` flag is set to false. 

This should address [this issue](https://github.com/netzpirat/haml_coffee_assets/issues/11).
