### PR TITLE
Process .jst.hamlc.* files as JST (e.g. .jst.hamlc.erb)

### DIFF
--- a/lib/haml_coffee_assets/haml_coffee_template.rb
+++ b/lib/haml_coffee_assets/haml_coffee_template.rb
@@ -32,7 +32,7 @@ module HamlCoffeeAssets
     # Compile the template.
     #
     def evaluate(scope, locals = { }, &block)
-      jst = scope.pathname.to_s =~ /\.jst\.hamlc$/ ? false : true
+      jst = scope.pathname.to_s =~ /\.jst\.hamlc(?:\.|$)/ ? false : true
       @output ||= HamlCoffee.compile(scope.logical_path, data, jst)
     end
 


### PR DESCRIPTION
With the asset pipeline, you are supposed to be able to chain engines by adding another file extension. But this wasn't working with, for example a *.jst.hamlc.erb file -- the result tried to use both haml_coffee_assets's and sprockets JST processing, leaving `JST[<template name>]` undefined.
