### PR TITLE
Define a wrapper function around CoffeeScript output

### DIFF
--- a/lib/haml_coffee_assets/haml_coffee_assets.js
+++ b/lib/haml_coffee_assets/haml_coffee_assets.js
@@ -68,12 +68,13 @@ var HamlCoffeeAssets = (function(){
 
         if (jst) {
           template = CoffeeScript.compile(compiler.render(name, namespace));
-        } else {
-          template = CoffeeScript.compile('(context) -> ( ->\n' + compiler.precompile().replace(/^(.*)$/mg, '  $1') + ').call(context)', { bare: true });
-        }
 
-        if (context !== '') {
-          template = template.replace('.call(context);', '.call(' + context +'(context));');
+          if (context !== '')
+            template = template.replace('.call(context);', '.call(' + context + '(context));');
+        } else {
+          template = CoffeeScript.compile(compiler.precompile(), { bare: true });
+          template = '(function() {\n' + template + '\n})';
+          template = '(function(context) { return ' + template + '.call(' + context + '(context)); })';
         }
 
         return template;


### PR DESCRIPTION
CoffeeScript in bare mode may emit var __bind and similar statements, so it is preferable to wrap the compiler output in plain JavaScript function and not to wrap the source in a CoffeeScript function.
