### PR TITLE
check for Mootools Object.append before prototype's Object.extend

### DIFF
--- a/vendor/assets/javascripts/hamlcoffee.js.coffee.erb
+++ b/vendor/assets/javascripts/hamlcoffee.js.coffee.erb
@@ -47,11 +47,11 @@ window.HAML.extend ||= (globals, locals) ->
   else if Zepto?.extend
     Zepto.extend(Zepto.extend({}, globals), locals)
 
-  else if Object.extend
-    Object.extend(Object.extend({}, globals), locals)
-
   else if Object.append
     Object.append(Object.append({}, globals), locals)
+    
+  else if Object.extend
+    Object.extend(Object.extend({}, globals), locals)
 
   else
     locals


### PR DESCRIPTION
Mootools uses `extend` internally so the existence of prototype's `Object.extend` must be checked after mootools `Object.append`
