### PR TITLE
Fix bug with Sprockets 2.0.3

### DIFF
--- a/lib/haml_coffee_assets.rb
+++ b/lib/haml_coffee_assets.rb
@@ -15,5 +15,6 @@ if defined?(Rails)
   require 'haml_coffee_assets/engine'
 else
   require 'sprockets'
+  require 'sprockets/engines'
   Sprockets.register_engine '.hamlc', HamlCoffeeAssets::HamlCoffeeTemplate
 end


### PR DESCRIPTION
I received the error:

undefined method `register_engine' for Sprockets:Module (NoMethodError)

So this patch just adds the require statement.
