### PR TITLE
Adds context to Haml

### DIFF
--- a/lib/haml_coffee_assets/haml_coffee_assets.js
+++ b/lib/haml_coffee_assets/haml_coffee_assets.js
@@ -70,7 +70,8 @@ var HamlCoffeeAssets = (function(){
           template = CoffeeScript.compile(compiler.render(name, namespace));
         } else {
           var hamlc = CoffeeScript.compile(compiler.precompile(), { bare: true });
-          template = '(function(context) {\n  return (function() {\n' + hamlc.replace(/^(.*)$/mg, '    $1') + '\n  }).call(context);\n});';
+          // template = '(function(context) {\n  return (function() {\n' + hamlc.replace(/^(.*)$/mg, '    $1') + '\n  }).call(context);\n});';
+          template = '(function(context) {with(context||{}){return (function() {' + hamlc + '}).call(context);} });';
         }
 
         if (context !== '') {


### PR DESCRIPTION
It seems you forgot to apply the context's scope to the Haml templates.

This patch allows for `%h3= user.name` instead of `%h3= context.user.name`.
