### PR TITLE
Small fix to options parsing in Rails engine

### DIFF
--- a/lib/haml_coffee_assets/engine.rb
+++ b/lib/haml_coffee_assets/engine.rb
@@ -51,7 +51,7 @@ module HamlCoffeeAssets
         config.customCleanValue      = options[:customCleanValue]
         config.customPreserve        = options[:customPreserve]
         config.customFindAndPreserve = options[:customFindAndPreserve]
-        config.customPreserve        = options[:customSurround]
+        config.customSurround        = options[:customSurround]
         config.customSucceed         = options[:customSucceed]
         config.customPrecede         = options[:customPrecede]
         config.preserveTags          = options[:preserve]


### PR DESCRIPTION
Should be self-explanatory.

One thing I did notice is that there are 2 sets of defaults in the repository - one in the configuration object and one in the Rails engine. Is there a plan to merge these at some point, or are there reasons why they should be kept separate?
