### PR TITLE
Update reference to CoffeeScript library.

### DIFF
--- a/lib/haml_coffee_assets/compiler.rb
+++ b/lib/haml_coffee_assets/compiler.rb
@@ -70,7 +70,7 @@ module HamlCoffeeAssets
       # @return [String] the source
       #
       def coffeescript
-        File.read CoffeeScript::Source.bundled_path
+        File.read CoffeeScript::Source.path
       end
 
       # Read a JavaScript file from the `js` dir.


### PR DESCRIPTION
Updated to use the [path method](https://github.com/josh/ruby-coffee-script/blob/master/lib/coffee_script.rb#L9) which checks the environment variable before the bundled path.
