### PR TITLE
AMD-Example-Link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Haml Coffee allows you to write inline [CoffeeScript](http://jashkenas.github.co
 ```
 
 You can try Haml Coffee online by visiting [Haml Coffee Online](http://haml-coffee-online.herokuapp.com/) and have a
-look [the AMD example Rails app](https://github.com/netzpirat/haml_coffee_assets_amd).
+look [the AMD example Rails app](https://github.com/netzpirat/haml_coffee_assets-amd-demo).
 
 ## Installation
 
@@ -465,7 +465,7 @@ Of course you can also directly require and render a template like:
 != require("another/other")()
 ```
 
-Please have a look at [the AMD example Rails app](https://github.com/netzpirat/haml_coffee_assets_amd) for a working
+Please have a look at [the AMD example Rails app](https://github.com/netzpirat/haml_coffee_assets-amd-demo) for a working
 example.
 
 ## Author


### PR DESCRIPTION
The Readme-AMD-Example-Links poined to the (i suppose old) location  https://github.com/netzpirat/haml_coffee_assets_amd

Updated to 
https://github.com/netzpirat/haml_coffee_assets-amd-demo
