### PR TITLE
Clear the template cache in development

### DIFF
--- a/lib/haml_coffee_assets/action_view/resolver.rb
+++ b/lib/haml_coffee_assets/action_view/resolver.rb
@@ -9,6 +9,7 @@ module HamlCoffeeAssets
     class Resolver < ::ActionView::FileSystemResolver
       def find_templates(name, prefix, partial, details)
         if details[:formats].include?(:html)
+          clear_cache if ::Rails.env == "development"
           super
         else
           []


### PR DESCRIPTION
Rails template caching is currently too aggressive for haml_coffee_assets.
In development wipe the cache when resolving template requests for html
content types.
