### PR TITLE
Don't butcher all template errors in Rails 4

### DIFF
--- a/lib/haml_coffee_assets/action_view/patches.rb
+++ b/lib/haml_coffee_assets/action_view/patches.rb
@@ -25,7 +25,16 @@ class ::ActionView::Template
         template = refresh(view)
         template.encode!
       end
-      raise ::ActionView::Template::Error.new(template, assigns, e)
+      if ::ActionView::Template::Error.instance_method(:initialize).arity == 3
+        # Rails < 4.0 expects three arguments here
+        raise ::ActionView::Template::Error.new(template, assigns, e)
+      elsif ::ActionView::Template::Error.instance_method(:initialize).arity == 2
+        # and Rails >= 4.0 expects two arguments
+        raise ::ActionView::Template::Error.new(template, e)
+      else
+        # try and fail graciously if this changes in the future
+        raise e
+      end
     end
   end
 end


### PR DESCRIPTION
Rails < 4.0 expects three arguments to ::ActionView::Template::Error.new, but Rails >= 4.0 expects just two. This was causing _all_ of my errors to be butchered and replaced by a "wrong number of arguments" error in the haml_coffee_assets code. This here checks for the number of arguments expected and should work with both old and new versions of Rails.
