### PR TITLE
Fix compatibility with Rails 4.1.0.rc1 

### DIFF
--- a/lib/haml_coffee_assets/action_view/resolver.rb
+++ b/lib/haml_coffee_assets/action_view/resolver.rb
@@ -1,7 +1,13 @@
 require "action_view"
+require 'active_support'
 
 module HamlCoffeeAssets
   module ActionView
+    extend ActiveSupport::Autoload
+    autoload_at "action_view/template/resolver" do
+      autoload :FileSystemResolver  
+    end
+    
     # Custom resolver to prevent Haml Coffee templates from being rendered by
     # Rails for non-HTML formats, since a template name without a MIME type
     # in it would normally be a fallback for all formats.


### PR DESCRIPTION
Fix compatibility with Rails 4.1.0.rc1 by forward-porting an autoload of FileSystemResolver
- This fixes haml_coffee_assets-1.16.0/lib/haml_coffee_assets/action_view/resolver.rb:9:in `module:ActionView': uninitialized constant ActionView::FileSystemResolver (NameError)
- This commit introduced the issue: https://github.com/rails/rails/commit/3fbff7811bc7142e6f4142f807dd7b6ebd766a13#diff-90f6f2b6859f5da65e11631ebcdf3f09
