### PR TITLE
Fix compatibility with Rails 4.1.0.rc1 since it no longer autoloads FileSystemResolver in action_view.rb

### DIFF
--- a/lib/haml_coffee_assets/action_view/resolver.rb
+++ b/lib/haml_coffee_assets/action_view/resolver.rb
@@ -1,4 +1,5 @@
 require "action_view"
+require 'action_view/template/resolver'
 
 module HamlCoffeeAssets
   module ActionView


### PR DESCRIPTION
Forward-porting a require statement to load FileSystemResolver
- This fixes haml_coffee_assets-1.16.0/lib/haml_coffee_assets/action_view/resolver.rb:9:in `module:ActionView': uninitialized constant ActionView::FileSystemResolver (NameError)
- For more details, see rails @ 3fbff7811bc7142e6f4142f807dd7b6ebd766a13 (https://github.com/rails/rails/commit/3fbff7811bc7142e6f4142f807dd7b6ebd766a13#diff-90f6f2b6859f5da65e11631ebcdf3f09)
