### PR TITLE
Handle properly boolean html attributes

### DIFF
--- a/lib/js/hamlcoffee.js
+++ b/lib/js/hamlcoffee.js
@@ -1667,6 +1667,9 @@ require.define("/nodes/haml.coffee",function(require,module,exports,__dirname,__
               }
             }
           } else {
+            if(['checked', 'readonly', 'disabled', 'selected', 'multiple', 'required', 'autofocus'].indexOf(key) != -1) {
+              value = value + ' || false '; 
+            }              
             tagParts.push("" + key + "=" + (this.quoteAndEscapeAttributeValue(this.interpolateCodeAttribute(value))));
           }
         }


### PR DESCRIPTION
Boolean attributes: https://www.w3.org/TR/2008/WD-html5-20080610/semantics.html#boolean
If we supply a null/nil value in a hamlc template the compiler doesn't
consider its value as a false and this boolean conversion doesn't work:
https://github.com/emilioforrer/haml_coffee_assets/blame/master/lib/js/hamlcoffee.js#L941
so we endup with a selected checkbox when we almost probably didn't want
that.

We can extend this list of boolean attributes with
https://html.spec.whatwg.org/#boolean-attributes

- input:

```
%input{name: "settings[foo_enabled]", type: 'checkbox', value: true, checked: @.foo_enabled}

```

- result:

before
```
$o.push("      </div>\n    </div>\n    <div class='row'>\n      <div class='checkbox'>\n        <input name='settings[foo_enabled]' type='checkbox' value checked='" + ($e($c(this.foo_enabled))) + "'>");
```
after
```
$o.push("      </div>\n    </div>\n    <div class='row'>\n      <div class='checkbox'>\n        <input name='settings[foo_enabled]' type='checkbox' value checked='" + ($e($c(this.foo_enabled || false))) + "'>");
```

