### PR TITLE
Silence sprockets deprecation warning

### DIFF
--- a/lib/haml_coffee_assets/rails/engine.rb
+++ b/lib/haml_coffee_assets/rails/engine.rb
@@ -80,7 +80,7 @@ module HamlCoffeeAssets
         next unless app.assets
 
         # Register Tilt template (for Sprockets)
-        app.assets.register_engine '.hamlc', ::HamlCoffeeAssets::Tilt::TemplateHandler
+        app.assets.register_engine '.hamlc', ::HamlCoffeeAssets::Tilt::TemplateHandler, silence_deprecation: true
       end
 
     end


### PR DESCRIPTION
This is probably part of a bigger issue, but no need to warn all users every time rails starts up.

[Sprockets documentation listed in the warning](https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors)