### PR TITLE
Fix interop error with Rails 5.1 Template Errors

### DIFF
--- a/lib/haml_coffee_assets/action_view/patches.rb
+++ b/lib/haml_coffee_assets/action_view/patches.rb
@@ -29,8 +29,10 @@ module HamlCoffeeAssets::ActionView
 
           if ::Rails::VERSION::STRING < "4"
             raise ::ActionView::Template::Error.new(template, assigns, e)
-          else
+          elsif ::Rails::VERSION::STRING < "5.1"
             raise ::ActionView::Template::Error.new(template, e)
+          else
+            raise ::ActionView::Template::Error.new(template)
           end
         end
       end

--- a/spec/haml_coffee_assets/action_view/patches_spec.rb
+++ b/spec/haml_coffee_assets/action_view/patches_spec.rb
@@ -64,5 +64,24 @@ describe HamlCoffeeAssets::ActionView::Patches do
         expect(template).to receive(:raise).with("An Error #2")
       end
     end
+
+    context "Rails >= 5.1.0" do
+      before do
+        stub_const("Rails::VERSION::STRING", "5.1.1")
+      end
+
+      it "should #refresh template" do
+        expect(template).to receive(:refresh).with(view)
+      end
+
+      it "should #encode! template" do
+        expect(template).to receive(:encode!)
+      end
+
+      it "should raise an error" do
+        expect(ActionView::Template::Error).to receive(:new).with(template).and_return("An Error #3")
+        expect(template).to receive(:raise).with("An Error #3")
+      end
+    end
   end
 end


### PR DESCRIPTION
#162 noted a deprecation error with Rails 5, and with Rails 5.1 it's a breaking change.

With this PR, `::ActionView::Template::Error` are created without the `original_exception` param, because it raises `ArgumentError: wrong number of arguments (given 2, expected 1)`