### PR TITLE
Upgrade ruby versions in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.3
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
   - ruby-head
   - jruby-9.0.5.0
+  - jruby-9.1.9.0
   - jruby-head
 gemfile:
-  - Gemfile
   - gemfiles/Gemfile-4-0-stable
   - gemfiles/Gemfile-4-1-stable
   - gemfiles/Gemfile-4-2-stable
@@ -16,7 +15,14 @@ gemfile:
   - gemfiles/Gemfile-5-1-stable
 matrix:
   exclude:
-    - gemfile: Gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile-4-0-stable
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile-4-1-stable
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile-4-0-stable
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile-4-1-stable
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
* Remove outdated ruby 2.0.x and 2.1.x
* Upgrade 2.2 and 2.3
* Add 2.4 (only [rails 4.2+](http://weblog.rubyonrails.org/2017/2/21/Rails-4-2-8-has-been-released/) supports it)
* Add jruby 9.1

This hopefully fix the travis builds