### PR TITLE
Must revert as this comes in as 'folder/file'

### DIFF
--- a/lib/haml_coffee_assets/transformer.rb
+++ b/lib/haml_coffee_assets/transformer.rb
@@ -22,7 +22,7 @@ module HamlCoffeeAssets
     end
 
     def self.call(input)
-      filename = input[:name]
+      filename = input[:filename]
       source   = input[:data]
       context  = input[:environment].context_class.new(input)
 

--- a/spec/haml_coffee_assets/assets_template_handler_spec.rb
+++ b/spec/haml_coffee_assets/assets_template_handler_spec.rb
@@ -36,4 +36,11 @@ describe HamlCoffeeAssets do
     expect(asset).not_to be_nil
     expect(asset.pathname.basename.to_s).to eq 'test.hamlc'
   end
+
+  it 'adds hamlc files into assets pipeline' do
+    jst = true
+    name = Dir.pwd + '/spec/haml_coffee_assets/support/testj.jst.hamlc'
+    expect(HamlCoffeeAssets::Compiler).to receive(:compile).with(name, "alert 'hi'\n", !jst).and_call_original
+    init_rails_app.assets.find_asset('testj')
+  end
 end

--- a/spec/haml_coffee_assets/support/testj.jst.hamlc
+++ b/spec/haml_coffee_assets/support/testj.jst.hamlc
@@ -1,0 +1,1 @@
+alert 'hi'

--- a/spec/haml_coffee_assets/transformer_spec.rb
+++ b/spec/haml_coffee_assets/transformer_spec.rb
@@ -15,6 +15,17 @@ describe HamlCoffeeAssets::Transformer do
         expect(HamlCoffeeAssets::Compiler).to receive(:compile).with('templates/foo/bar.jst.hamlc', '%h2', false)
         transformer.render(nil, {})
       end
+
+      context '#call' do
+        let(:filepath) { '/path/to/templates/foo/bar.jst.hamlc' }
+        let(:environment) { double(context_class: double(new: double(metadata: {}))) }
+        let(:input) { { data: '%h2', name: 'foo/bar', filename: filepath, environment: environment } }
+
+        it 'works with sprockets inputs' do
+          expect(HamlCoffeeAssets::Compiler).to receive(:compile).with(filepath, '%h2', false)
+          HamlCoffeeAssets::Transformer.call(input)
+        end
+      end
     end
 
     context 'for a HAMLC template' do


### PR DESCRIPTION
I have an issue with this commit: https://github.com/emilioforrer/haml_coffee_assets/commit/9f02cabc7575cd60b2f0c0ae75a2cc082de4e2eb

I'm upgrading from Rails 4.2 to Rails 5.0, but it appears the issue for me is I'm upgrading sprockets 2 to 3 in that process.

In doing so I have to upgrade from haml_coffee_assets 1.16.2 to a later version (1.18, but 1.17 would have the same problem as it has the above commit), which introduces an issue for us.

We use the ".jst.hamlc" style (not the plain .hamlc) style.

We reference our template as "JST['folder/file']" which is referencing app/assets/templates/folder/file.jst.hamlc

Unfortunately sprockets (I'm using 3.7.1) at "sprockets-3.7.1/lib/sprockets/loader.rb" defines "name" variable as "folder/file". This goes through the code to haml_coffee_assets/transformer.rb which uses input[:file] ("folder/file") and it passes this "filename" to the run method in transformer.rb which does:

```ruby
jst = !!(filename =~ /\.jst\.hamlc(?:\.|$)/)
```

Which because filename is "folder/file" it has not jst therefore thinks it is not a JST file and thus is incorrect.

I don't think we are expected to do "JST['folder/file.jst.hamlc']" (which would ensure the 'file' variable has the correct data to determine if it is JST or not).

Regarding sprockets 3.7, I've tried using sprockets 3.6 and even 3.3 (to test an older one) and "name" is still without any extension.

I would be interested in your thoughts on this change because it is reverting a commit that stops a deprecation, but maybe there is another way of solving that deprecation without breaking the functionality as I described.