### PR TITLE
Use Rails 6 default buffer in render instead of nil

### DIFF
--- a/lib/haml_coffee_assets/rails/engine.rb
+++ b/lib/haml_coffee_assets/rails/engine.rb
@@ -60,7 +60,7 @@ module HamlCoffeeAssets
 
               # by default, rails will only compile a template once
               # path render so it recompiles the template if 'stale'
-              def render(view, locals, buffer=nil, &block)
+              def render(view, locals, buffer=::ActionView::OutputBuffer.new, &block)
                 if @compiled and stale?
                   now = Time.now
                   File.utime(now, now, identifier) # touch file


### PR DESCRIPTION
According to this, it looks like the method signature for `render` has changed in rails 6 to include a default buffer.  

This updates the overridden method here to match the same upstream signature. 

Fixes #176 