### PR TITLE
JST support on Sprockets 4 

### DIFF
--- a/lib/haml_coffee_assets/rails/engine.rb
+++ b/lib/haml_coffee_assets/rails/engine.rb
@@ -35,8 +35,9 @@ module HamlCoffeeAssets
 
         config.assets.configure do |env|
           if env.respond_to?(:register_transformer)
-            env.register_mime_type 'text/hamlc', extensions: ['.hamlc']
+            env.register_mime_type 'text/hamlc', extensions: ['.hamlc', '.jst.hamlc']
             env.register_transformer 'text/hamlc', 'application/javascript', ::HamlCoffeeAssets::Transformer
+            env.register_transformer 'text/hamlc', 'application/javascript+function', ::HamlCoffeeAssets::Transformer
           end
 
           if env.respond_to?(:register_engine)


### PR DESCRIPTION
Sprockets 4 changes the way paths with multiple extensions are resolved, and that causes imports of `.jst.hamlc` files to end in file-not-found precompilation errors. And even if you get past that, the `JstProcessor` would not be included in its processor chain, unless the file type that comes out of `HamlTransformer` is  `application/javascript+function`.
The solution is to follow the JST registration pattern that S4 uses internally for `text/eco`, `text/ejs`, which it supports out of the box.