### PR TITLE
properly support nested ERB for .jst.hamlc with Sprockets 4

### DIFF
--- a/lib/haml_coffee_assets/rails/engine.rb
+++ b/lib/haml_coffee_assets/rails/engine.rb
@@ -36,13 +36,17 @@ module HamlCoffeeAssets
         config.assets.configure do |env|
           if env.respond_to?(:register_transformer)
             env.register_mime_type 'text/hamlc', extensions: ['.hamlc']
-            env.register_mime_type 'text/jst+hamlc', extensions: ['.jst.hamlc']
             env.register_transformer 'text/hamlc', 'application/javascript', ::HamlCoffeeAssets::Transformer
+
+            env.register_mime_type 'text/jst+hamlc', extensions: ['.jst.hamlc']
             env.register_transformer 'text/jst+hamlc', 'application/javascript+function', ::HamlCoffeeAssets::Transformer
 
             # support for chaining via ERB, documented via https://github.com/rails/sprockets/pull/807
-            env.register_mime_type 'text/hamlc+ruby', extensions: ['.hamlc.erb', '.jst.hamlc.erb']
+            env.register_mime_type 'text/hamlc+ruby', extensions: ['.hamlc.erb']
             env.register_transformer 'text/hamlc+ruby', 'text/hamlc', ::Sprockets::ERBProcessor
+
+            env.register_mime_type 'text/jst+hamlc+ruby', extensions: ['.jst.hamlc.erb']
+            env.register_transformer 'text/jst+hamlc+ruby', 'text/jst+hamlc', ::Sprockets::ERBProcessor
           end
 
           if env.respond_to?(:register_engine)


### PR DESCRIPTION
While we don't really use this, there's a logical bug here which will cause an issue if nested ERB templates are used with `.jst.hamlc` files.

@voducvu can you also test this and verify that it works before @mathieujobin approves/merges this?